### PR TITLE
2021-07-07 ROYAL-1834 Update ActionPolicy for REST requests to handle all exceptions

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // 2.9.0.0 - magento 2 supported, 9 build, 0 subversion (includes significant features and codechanges)
 
-[ assembly : AssemblyVersion( "2.18.4.0" ) ]
+[ assembly : AssemblyVersion( "2.18.5.0" ) ]

--- a/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
+++ b/src/MagentoAccess/Services/Rest/v2x/Repository/ActionPolicies.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using MagentoAccess.Misc;
 using Netco.ActionPolicyServices;
@@ -9,26 +7,7 @@ namespace MagentoAccess.Services.Rest.v2x.Repository
 {
 	internal static class ActionPolicies
 	{
-		public static ActionPolicyAsync RepeatOnChannelProblemAsync { get; } = ActionPolicyAsync.From( ( exception =>
-		{
-			var magentoWebException = exception as MagentoWebException;
-			if ( magentoWebException != null 
-				&& magentoWebException.StatusCode != null )
-			{
-				switch( magentoWebException.StatusCode )
-				{
-					case HttpStatusCode.NotFound:
-					case HttpStatusCode.BadRequest:
-					case HttpStatusCode.ServiceUnavailable:
-					case HttpStatusCode.BadGateway:
-						return true;
-					default:
-						return false;
-				}
-			}
-
-			return false;
-		} ) )
+		public static ActionPolicyAsync RepeatOnChannelProblemAsync { get; } = ActionPolicyAsync.Handle< Exception >()
 			.RetryAsync( 7, async ( ex, i ) =>
 			{
 				MagentoLogger.Log().Trace( ex, "Retrying Magento API call due to channel problem for the {0} time", i );


### PR DESCRIPTION
The client.GetAsync, client.PostAsync, and client.PutAsync calls (https://github.com/skuvault-integrations/magentoAccess/blob/master/src/MagentoAccess/Services/WebRequestServices.cs#L67) can throw different types of exceptions that weren't handled by Rest ActionPolicies.